### PR TITLE
versions to 5.1.5/6.1.4/6.0.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,10 @@
 # Changelog
 
-- bug fix for passing `DCSizes` param to opscenter.template in no-vpc template
+- versions to DSE 5.1.5, OpsC 6.1.4, scripts 6.0.1. Fixes JCE download bug.
 ---
 ## Previous Commits
+---
+- bug fix for passing `DCSizes` param to opscenter.template in no-vpc template
 ---
 - bump versions: DSE -> 5.1.3, OpsCenter -> 6.1.3, install scripts -> 6.0.0
 - LCM install job triggered from OpsCenter instance, required shifting params

--- a/templates/datacenter.template
+++ b/templates/datacenter.template
@@ -586,7 +586,7 @@
                                             "sleep 15s \n",
                                             "done \n",
                                             "cat .ssh/lcm.pem.pub >> .ssh/authorized_keys \n",
-                                            "release=\"6.0.0\" \n",
+                                            "release=\"6.0.1\" \n",
                                             "wget https://github.com/DSPN/install-datastax-ubuntu/archive/$release.zip \n",
                                             "unzip $release.zip \n",
                                             "cd install-datastax-ubuntu-$release/bin/lcm \n",

--- a/templates/opscenter.template
+++ b/templates/opscenter.template
@@ -533,8 +533,8 @@
                                             "cloud_type=\"aws\" \n",
                                             "cd ~ubuntu \n",
                                             "apt-get -y install unzip \n",
-                                            "release=\"6.0.0\" \n",
-                                            "export OPSC_VERSION='6.1.3' \n",
+                                            "release=\"6.0.1\" \n",
+                                            "export OPSC_VERSION='6.1.4' \n",
                                             "wget https://github.com/DSPN/install-datastax-ubuntu/archive/$release.zip \n",
                                             "unzip $release.zip \n",
                                             "cd install-datastax-ubuntu-$release/bin \n",
@@ -585,7 +585,7 @@
                                             "#!/usr/bin/env bash -e \n",
                                             "cd ~ubuntu \n",
                                             "pip install requests \n",
-                                            "release=\"6.0.0\" \n",
+                                            "release=\"6.0.1\" \n",
                                             "cd install-datastax-ubuntu-$release/bin/lcm \n",
                                             "privkey=$(readlink -f ~ubuntu/.ssh/lcm.pem) \n",
                                             "sleep 1m \n",
@@ -596,7 +596,7 @@
                                                 "Ref": "ClusterName"
                                             },
                                             "' ",
-                                            "--dsever '5.1.3' ",
+                                            "--dsever '5.1.5' ",
                                             "--repouser '",
                                             {
                                                 "Ref": "DSAcademyUser"
@@ -624,7 +624,7 @@
                                         "",
                                         [
                                             "#!/usr/bin/env bash -e \n",
-                                            "release=\"6.0.0\" \n",
+                                            "release=\"6.0.1\" \n",
                                             "/usr/local/bin/cfn-signal -e 0 -r \"OpsCenter Setup Complete\" \"",
                                             {
                                                 "Ref": "OpsCenterWaitHandle"


### PR DESCRIPTION
Versions are now:
- DSE 5.1.5 (patches Solr security bug)
- OpsCenter 6.1.4 (fixes Oracle JCE URL bug)
- scripts 6.0.1