### PR TITLE
update versions, increase timeout

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,12 @@
 # Changelog
 
-- versions to DSE 5.1.5, OpsC 6.1.4, scripts 6.0.1. Fixes JCE download bug.
+- versions to DSE 5.1.6, OpsC 6.1.5, scripts 6.0.4. Fixes java 8u162 startup bug.
+- increase CassandraGroup timeout to 35m
+
 ---
 ## Previous Commits
+---
+- versions to DSE 5.1.5, OpsC 6.1.4, scripts 6.0.1. Fixes JCE download bug.
 ---
 - bug fix for passing `DCSizes` param to opscenter.template in no-vpc template
 ---

--- a/templates/datacenter.template
+++ b/templates/datacenter.template
@@ -446,7 +446,7 @@
             },
             "CreationPolicy": {
                 "ResourceSignal": {
-                    "Timeout": "PT30M",
+                    "Timeout": "PT35M",
                     "Count": "1"
                 }
             },
@@ -454,7 +454,7 @@
                 "AutoScalingRollingUpdate": {
                     "MinInstancesInService": "1",
                     "MaxBatchSize": "1",
-                    "PauseTime": "PT30M",
+                    "PauseTime": "PT35M",
                     "WaitOnResourceSignals": "true"
                 }
             }
@@ -586,7 +586,7 @@
                                             "sleep 15s \n",
                                             "done \n",
                                             "cat .ssh/lcm.pem.pub >> .ssh/authorized_keys \n",
-                                            "release=\"6.0.1\" \n",
+                                            "release=\"6.0.4\" \n",
                                             "wget https://github.com/DSPN/install-datastax-ubuntu/archive/$release.zip \n",
                                             "unzip $release.zip \n",
                                             "cd install-datastax-ubuntu-$release/bin/lcm \n",
@@ -710,7 +710,7 @@
             },
             "CreationPolicy": {
                 "ResourceSignal": {
-                    "Timeout": "PT30M"
+                    "Timeout": "PT35M"
                 }
             }
         },

--- a/templates/opscenter.template
+++ b/templates/opscenter.template
@@ -533,8 +533,8 @@
                                             "cloud_type=\"aws\" \n",
                                             "cd ~ubuntu \n",
                                             "apt-get -y install unzip \n",
-                                            "release=\"6.0.1\" \n",
-                                            "export OPSC_VERSION='6.1.4' \n",
+                                            "release=\"6.0.4\" \n",
+                                            "export OPSC_VERSION='6.1.5' \n",
                                             "wget https://github.com/DSPN/install-datastax-ubuntu/archive/$release.zip \n",
                                             "unzip $release.zip \n",
                                             "cd install-datastax-ubuntu-$release/bin \n",
@@ -585,7 +585,7 @@
                                             "#!/usr/bin/env bash -e \n",
                                             "cd ~ubuntu \n",
                                             "pip install requests \n",
-                                            "release=\"6.0.1\" \n",
+                                            "release=\"6.0.4\" \n",
                                             "cd install-datastax-ubuntu-$release/bin/lcm \n",
                                             "privkey=$(readlink -f ~ubuntu/.ssh/lcm.pem) \n",
                                             "sleep 1m \n",
@@ -596,7 +596,7 @@
                                                 "Ref": "ClusterName"
                                             },
                                             "' ",
-                                            "--dsever '5.1.5' ",
+                                            "--dsever '5.1.6' ",
                                             "--repouser '",
                                             {
                                                 "Ref": "DSAcademyUser"
@@ -624,7 +624,7 @@
                                         "",
                                         [
                                             "#!/usr/bin/env bash -e \n",
-                                            "release=\"6.0.1\" \n",
+                                            "release=\"6.0.4\" \n",
                                             "/usr/local/bin/cfn-signal -e 0 -r \"OpsCenter Setup Complete\" \"",
                                             {
                                                 "Ref": "OpsCenterWaitHandle"


### PR DESCRIPTION
- versions to DSE 5.1.6, OpsC 6.1.5, scripts 6.0.4. Fixes java 8u162 startup bug.
- timeout was getting hit ~50% of the time for large deployments in taskcat testing, added 5m.