### PR TITLE
install scripts 6.1.0, https/auth on at start

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,16 @@
 # Changelog
 
-- versions to DSE 5.1.6, OpsC 6.1.5, scripts 6.0.4. Fixes java 8u162 startup bug.
-- increase CassandraGroup timeout to 35m
+- install scripts to 6.1.0
+- all LCM REST calls use https/auth
+- OpsC PW params added/passed to datacenter.template
+- shell cleanup
 
 ---
 ## Previous Commits
+---
+- versions to DSE 5.1.6, OpsC 6.1.5, scripts 6.0.4. Fixes java 8u162 startup bug.
+- increase CassandraGroup timeout to 35m
+
 ---
 - versions to DSE 5.1.5, OpsC 6.1.4, scripts 6.0.1. Fixes JCE download bug.
 ---

--- a/templates/datacenter.template
+++ b/templates/datacenter.template
@@ -13,6 +13,11 @@
             "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})",
             "ConstraintDescription": "must be valid IP"
         },
+        "OpsCPassword": {
+            "Type": "String",
+            "Description": "Password for default OpsCenter user 'admin'",
+            "NoEcho": true
+        },
         "ClusterName": {
             "Description": "Name of DSE cluster",
             "Type": "String"
@@ -567,7 +572,6 @@
                                         [
                                             "#!/usr/bin/env bash -e \n",
                                             "apt-get -y install awscli unzip\n",
-                                            "pip install requests \n",
                                             "cd ~ubuntu \n",
                                             "n=1 \n",
                                             "until [ $n -ge 8 ] \n",
@@ -586,15 +590,17 @@
                                             "sleep 15s \n",
                                             "done \n",
                                             "cat .ssh/lcm.pem.pub >> .ssh/authorized_keys \n",
-                                            "release=\"6.0.4\" \n",
-                                            "wget https://github.com/DSPN/install-datastax-ubuntu/archive/$release.zip \n",
-                                            "unzip $release.zip \n",
-                                            "cd install-datastax-ubuntu-$release/bin/lcm \n",
+                                            "release=\"6.1.0\" \n",
+                                            "export OPSC_VERSION='6.1.5' \n",
+                                            "wget https://github.com/DSPN/install-datastax-ubuntu/archive/$release.tar.gz \n",
+                                            "tar -xvf $release.tar.gz \n",
+                                            "cd install-datastax-ubuntu-$release/bin \n",
+                                            "./os/extra_packages.sh \n",
                                             "privip=$(curl http://169.254.169.254/latest/meta-data/local-ipv4) \n",
                                             "nodeid=$(curl http://169.254.169.254/latest/meta-data/instance-id) \n",
                                             "rack=$(curl http://169.254.169.254/latest/meta-data/placement/availability-zone) \n",
                                             "echo 'Calling addNode.py...' \n",
-                                            "./addNode.py ",
+                                            "./lcm/addNode.py ",
                                             " --opsc-ip ",
                                             {
                                                 "Ref": "OpsCenterIP"
@@ -604,7 +610,7 @@
                                                 "Ref": "ClusterName"
                                             },
                                             "' ",
-                                            "--dcname '",
+                                            " --dcname '",
                                             {
                                                 "Ref": "DataCenterName"
                                             },
@@ -612,13 +618,22 @@
                                             " --rack $rack",
                                             " --pubip $privip",
                                             " --privip $privip",
-                                            " --nodeid $nodeid \n",
-                                            "./waitForJobs.py ",
+                                            " --nodeid $nodeid",
+                                            " --opscpw '",
+                                            {
+                                                "Ref": "OpsCPassword"
+                                            },
+                                            "' \n",
+                                            "./lcm/waitForJobs.py ",
                                             " --opsc-ip ",
                                             {
                                                 "Ref": "OpsCenterIP"
                                             },
-                                            " \n"
+                                            " --opscpw '",
+                                            {
+                                                "Ref": "OpsCPassword"
+                                            },
+                                            "' \n"
                                         ]
                                     ]
                                 }

--- a/templates/opscenter.template
+++ b/templates/opscenter.template
@@ -532,15 +532,18 @@
                                             "#!/usr/bin/env bash -e \n",
                                             "cloud_type=\"aws\" \n",
                                             "cd ~ubuntu \n",
-                                            "apt-get -y install unzip \n",
-                                            "release=\"6.0.4\" \n",
+                                            "release=\"6.1.0\" \n",
                                             "export OPSC_VERSION='6.1.5' \n",
-                                            "wget https://github.com/DSPN/install-datastax-ubuntu/archive/$release.zip \n",
-                                            "unzip $release.zip \n",
+                                            "wget https://github.com/DSPN/install-datastax-ubuntu/archive/$release.tar.gz \n",
+                                            "tar -xvf $release.tar.gz \n",
                                             "cd install-datastax-ubuntu-$release/bin \n",
+                                            "./os/extra_packages.sh \n",
                                             "./os/install_java.sh \n",
                                             "./opscenter/install.sh $cloud_type \n",
-                                            "./opscenter/start.sh"
+                                            "./opscenter/set_opsc_pw_https.sh ",
+                                            {
+                                                "Ref": "OpsCPassword"
+                                            },
                                         ]
                                     ]
                                 }
@@ -584,32 +587,35 @@
                                         [
                                             "#!/usr/bin/env bash -e \n",
                                             "cd ~ubuntu \n",
-                                            "pip install requests \n",
-                                            "release=\"6.0.4\" \n",
-                                            "cd install-datastax-ubuntu-$release/bin/lcm \n",
+                                            "release=\"6.1.0\" \n",
+                                            "cd install-datastax-ubuntu-$release/bin \n",
                                             "privkey=$(readlink -f ~ubuntu/.ssh/lcm.pem) \n",
                                             "sleep 1m \n",
-                                            "./setupCluster.py ",
-                                            "--opsc-ip 127.0.0.1 ",
+                                            "./lcm/setupCluster.py ",
                                             " --clustername '",
                                             {
                                                 "Ref": "ClusterName"
                                             },
                                             "' ",
-                                            "--dsever '5.1.6' ",
-                                            "--repouser '",
+                                            " --dsever '5.1.6'",
+                                            " --repouser '",
                                             {
                                                 "Ref": "DSAcademyUser"
                                             },
                                             "' ",
-                                            "--repopw '",
+                                            " --repopw '",
                                             {
                                                 "Ref": "DSAcademyPW"
                                             },
                                             "' ",
-                                            "--privkey $privkey ",
-                                            "--user ubuntu ",
-                                            "--datapath \"/data/cassandra\" \n"
+                                            " --privkey $privkey",
+                                            " --user ubuntu",
+                                            " --datapath \"/data/cassandra\"",
+                                            " --opscpw '",
+                                            {
+                                                "Ref": "OpsCPassword"
+                                            },
+                                            "' \n",
                                         ]
                                     ]
                                 }
@@ -624,13 +630,13 @@
                                         "",
                                         [
                                             "#!/usr/bin/env bash -e \n",
-                                            "release=\"6.0.4\" \n",
+                                            "release=\"6.1.0\" \n",
                                             "/usr/local/bin/cfn-signal -e 0 -r \"OpsCenter Setup Complete\" \"",
                                             {
                                                 "Ref": "OpsCenterWaitHandle"
                                             },
                                             "\" \n",
-                                            "cd ~ubuntu/install-datastax-ubuntu-$release/bin/lcm \n",
+                                            "cd ~ubuntu/install-datastax-ubuntu-$release/bin \n",
                                             "echo 'Triggering install...' \n",
                                             "csize=$(( ",
                                             {
@@ -648,27 +654,41 @@
                                             },
                                             " )) \n",
                                             "echo csize=$csize \n",
-                                            "./triggerInstall.py ",
-                                            "--opsc-ip 127.0.0.1 ",
+                                            "./lcm/triggerInstall.py ",
                                             " --clustername '",
                                             {
                                                 "Ref": "ClusterName"
                                             },
                                             "' ",
-                                            "--clustersize $csize ",
-                                            "--dclevel ",
-                                            "--dbpasswd '",
+                                            " --clustersize $csize ",
+                                            " --dclevel ",
+                                            " --dbpasswd '",
                                             {
                                                 "Ref": "DBPassword"
                                             },
+                                            "' ",
+                                            " --opscpw '",
+                                            {
+                                                "Ref": "OpsCPassword"
+                                            },
                                             "' \n",
                                             "echo 'Blocking execution till LCM jobs finish...' \n",
-                                            "./waitForJobs.py --num ",
+                                            "./lcm/waitForJobs.py --num ",
                                             {
                                                 "Ref": "NumberDCs"
                                             },
-                                            " \n",
-                                            "./alterKeyspaces.py \n",
+                                            " --opscpw '",
+                                            {
+                                                "Ref": "OpsCPassword"
+                                            },
+                                            "' \n",
+                                            "./lcm/alterKeyspaces.py ",
+                                            " --opscpw '",
+                                            {
+                                                "Ref": "OpsCPassword"
+                                            },
+                                            "' \n",
+                                            "echo 'Removing lcm.pem.pub from bucket...' \n",
                                             "aws s3 rm s3://",
                                             {
                                                 "Ref": "S3Bucket"
@@ -677,13 +697,7 @@
                                             {
                                                 "Ref": "AWS::Region"
                                             },
-                                            " \n",
-                                            "cd ../opscenter/ \n",
-                                            "./set_opsc_pw_https.sh '",
-                                            {
-                                                "Ref": "OpsCPassword"
-                                            },
-                                            "' \n"
+                                            " \n"
                                         ]
                                     ]
                                 }

--- a/templates/quickstart-datastax-master.template
+++ b/templates/quickstart-datastax-master.template
@@ -477,6 +477,9 @@
                     "OpsCenterIP": {
                         "Fn::GetAtt": ["OpsCenterstack", "Outputs.OpsCenterPrivateIP"]
                     },
+                    "OpsCPassword": {
+                        "Ref": "OpsCPassword"
+                    },
                     "ClusterName": {
                         "Ref": "ClusterName"
                     },
@@ -553,6 +556,9 @@
                     },
                     "OpsCenterIP": {
                         "Fn::GetAtt": ["OpsCenterstack", "Outputs.OpsCenterPrivateIP"]
+                    },
+                    "OpsCPassword": {
+                        "Ref": "OpsCPassword"
                     },
                     "ClusterName": {
                         "Ref": "ClusterName"
@@ -631,6 +637,9 @@
                     "OpsCenterIP": {
                         "Fn::GetAtt": ["OpsCenterstack", "Outputs.OpsCenterPrivateIP"]
                     },
+                    "OpsCPassword": {
+                        "Ref": "OpsCPassword"
+                    },
                     "ClusterName": {
                         "Ref": "ClusterName"
                     },
@@ -707,6 +716,9 @@
                     },
                     "OpsCenterIP": {
                         "Fn::GetAtt": ["OpsCenterstack", "Outputs.OpsCenterPrivateIP"]
+                    },
+                    "OpsCPassword": {
+                        "Ref": "OpsCPassword"
                     },
                     "ClusterName": {
                         "Ref": "ClusterName"

--- a/templates/quickstart-datastax-no-vpc.template
+++ b/templates/quickstart-datastax-no-vpc.template
@@ -477,6 +477,9 @@
                     "OpsCenterIP": {
                         "Fn::GetAtt": ["OpsCenterstack", "Outputs.OpsCenterPrivateIP"]
                     },
+                    "OpsCPassword": {
+                        "Ref": "OpsCPassword"
+                    },
                     "ClusterName": {
                         "Ref": "ClusterName"
                     },
@@ -548,6 +551,9 @@
                     },
                     "OpsCenterIP": {
                         "Fn::GetAtt": ["OpsCenterstack", "Outputs.OpsCenterPrivateIP"]
+                    },
+                    "OpsCPassword": {
+                        "Ref": "OpsCPassword"
                     },
                     "ClusterName": {
                         "Ref": "ClusterName"
@@ -621,6 +627,9 @@
                     "OpsCenterIP": {
                         "Fn::GetAtt": ["OpsCenterstack", "Outputs.OpsCenterPrivateIP"]
                     },
+                    "OpsCPassword": {
+                        "Ref": "OpsCPassword"
+                    },
                     "ClusterName": {
                         "Ref": "ClusterName"
                     },
@@ -692,6 +701,9 @@
                     },
                     "OpsCenterIP": {
                         "Fn::GetAtt": ["OpsCenterstack", "Outputs.OpsCenterPrivateIP"]
+                    },
+                    "OpsCPassword": {
+                        "Ref": "OpsCPassword"
                     },
                     "ClusterName": {
                         "Ref": "ClusterName"


### PR DESCRIPTION
Changes to install scripts and related template changes in preparation for future post-deploy flexibility.

From changelog:
- install scripts to 6.1.0
- all LCM REST calls use https/auth
- OpsC PW params added/passed to datacenter.template
- shell cleanup
